### PR TITLE
dcbumpgen wouldn't compile without -lm

### DIFF
--- a/utils/dcbumpgen/Makefile
+++ b/utils/dcbumpgen/Makefile
@@ -2,7 +2,7 @@
 # Makefile stolen from the kmgenc program.
 
 CFLAGS = -O2 -Wall -DINLINE=inline -I/usr/local/include
-LDFLAGS = -s -lpng -ljpeg -lz -L/usr/local/lib
+LDFLAGS = -s -lpng -ljpeg -lm -lz -L/usr/local/lib
 
 all: dcbumpgen
 


### PR DESCRIPTION
Recompiled KOS, dcbumpgen did not compile. Needed to add -lm due to some atan2 function I think.
